### PR TITLE
Add adminLevels to the reverse geocode function

### DIFF
--- a/ArcGISOnline.php
+++ b/ArcGISOnline.php
@@ -133,9 +133,14 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
         $streetName = !empty($data->Address) ? $data->Address : null;
         $city = !empty($data->City) ? $data->City : null;
         $zipcode = !empty($data->Postal) ? $data->Postal : null;
-        $region = !empty($data->Region) ? $data->Region : null;
-        $county = !empty($data->Subregion) ? $data->Subregion : null;
         $countryCode = !empty($data->CountryCode) ? $data->CountryCode : null;
+        
+        $adminLevels = [];
+        foreach (['Region', 'Subregion'] as $i => $property) {
+            if (!empty($data->{$property})) {
+                $adminLevels[] = ['name' => $data->{$property}, 'level' => $i + 1];
+            }
+        }
 
         return new AddressCollection([
             Address::createFromArray([
@@ -145,9 +150,8 @@ final class ArcGISOnline extends AbstractHttpProvider implements Provider
                 'streetName' => $streetName,
                 'locality' => $city,
                 'postalCode' => $zipcode,
-                'region' => $region,
-                'countryCode' => $countryCode,
-                'county' => $county,
+                'adminLevels' => $adminLevels,
+                'countryCode' => $countryCode
             ]),
         ]);
     }


### PR DESCRIPTION
I was wondering why when using ArcGIS Online as a reverse geocoder would not return the United States state and the county. It turns out that the provider wasn't even returning an "adminLevels" array, which is what every other reverse geocode provider returns. 